### PR TITLE
Fix comment full visibility on mobile

### DIFF
--- a/src/components/CommentFooter/CommentFooter.less
+++ b/src/components/CommentFooter/CommentFooter.less
@@ -4,6 +4,12 @@
   padding: 8px 0;
   color: @blue-botticelli;
   line-height: 14px;
+  
+  span:nth-child(7) > span{
+		display: block;
+		visibility: hidden;
+		line-height: 0.5;
+	  }
 
   &__payout {
     font-weight: bold;


### PR DESCRIPTION
Fixes :

fixing comment full visibility on mobile by adding new css params to CommentFooter .

Isuue by espoem [https://github.com/busyorg/busy/issues/1036](https://github.com/busyorg/busy/issues/1036)

Changes:

Changes on busy/src/components/CommentFooter/CommentFooter.lss
by adding a new style for the commentfooter
```
span:nth-child(7) > span{
		display: block!important;
		visibility: hidden!important;
		line-height: 0.5!important;
	  }
```
